### PR TITLE
Update PHP to 8.1

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -5,7 +5,7 @@
 name: app
 
 # The runtime the application uses.
-type: "php:7.4"
+type: 'php:8.1'
 
 runtime:
     extensions:


### PR DESCRIPTION
## Description
PHP7.4 is EOL. Upgrade to 8.1

## Related Issue
https://github.com/platformsh/template-builder/issues/703 

## Motivation and Context
PHP 7.4 is EOL